### PR TITLE
fix: patch eslint-parser-plain to export meta object

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,6 +156,11 @@
     "typescript": "^5.4.2",
     "vitest": "^1.3.1"
   },
+  "pnpm": {
+    "patchedDependencies": {
+      "eslint-parser-plain@0.1.0": "patches/eslint-parser-plain@0.1.0.patch"
+    }
+  },
   "simple-git-hooks": {
     "pre-commit": "pnpm lint-staged"
   },

--- a/patches/eslint-parser-plain@0.1.0.patch
+++ b/patches/eslint-parser-plain@0.1.0.patch
@@ -1,0 +1,50 @@
+diff --git a/dist/index.cjs b/dist/index.cjs
+index 6f434ee828045269e365e493e96227f4f28c4a91..c3e928e47ee037e8e188e3276e28db99a17c6316 100644
+--- a/dist/index.cjs
++++ b/dist/index.cjs
+@@ -1,5 +1,10 @@
+ 'use strict';
+ 
++const {
++  name: packageName,
++  version: packageVersion
++} = require("../package.json");
++
+ const parseForESLint = (code) => ({
+   ast: {
+     type: "Program",
+@@ -16,4 +21,10 @@ const parseForESLint = (code) => ({
+   }
+ });
+ 
++const meta = {
++  name: packageName,
++  version: packageVersion,
++}
++
+ exports.parseForESLint = parseForESLint;
++exports.meta = meta;
+diff --git a/dist/index.mjs b/dist/index.mjs
+index bdd48faa1bb1716f3037dfcf7a263c90022f40d0..aa7d894b2b760b9eed7afc3df32db87d5f6e677c 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -1,3 +1,8 @@
++import {
++  name as packageName,
++  version as packageVersion,
++} from "../package.json";
++
+ const parseForESLint = (code) => ({
+   ast: {
+     type: "Program",
+@@ -14,4 +19,9 @@ const parseForESLint = (code) => ({
+   }
+ });
+ 
+-export { parseForESLint };
++const meta = {
++  name: packageName,
++  version: packageVersion,
++}
++
++export { parseForESLint, meta };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  eslint-parser-plain@0.1.0:
+    hash: 2wwjuy7bj3rwnupmtdrepccgsy
+    path: patches/eslint-parser-plain@0.1.0.patch
+
 dependencies:
   '@antfu/eslint-define-config':
     specifier: ^1.23.0-2
@@ -43,7 +48,7 @@ dependencies:
     version: 0.1.0(eslint@8.57.0)
   eslint-parser-plain:
     specifier: ^0.1.0
-    version: 0.1.0
+    version: 0.1.0(patch_hash=2wwjuy7bj3rwnupmtdrepccgsy)
   eslint-plugin-antfu:
     specifier: ^2.1.2
     version: 2.1.2(eslint@8.57.0)
@@ -2046,8 +2051,9 @@ packages:
       eslint: 8.57.0
     dev: false
 
-  /eslint-parser-plain@0.1.0:
+  /eslint-parser-plain@0.1.0(patch_hash=2wwjuy7bj3rwnupmtdrepccgsy):
     resolution: {integrity: sha512-oOeA6FWU0UJT/Rxc3XF5Cq0nbIZbylm7j8+plqq0CZoE6m4u32OXJrR+9iy4srGMmF6v6pmgvP1zPxSRIGh3sg==}
+    patched: true
 
   /eslint-plugin-antfu@2.1.2(eslint@8.57.0):
     resolution: {integrity: sha512-s7ZTOM3uq0iqpp6gF0UEotnvup7f2PHBUftCytLZX0+6C9j9KadKZQh6bVVngAyFgsmeD9+gcBopOYLClb2oDg==}
@@ -2098,7 +2104,7 @@ packages:
       '@dprint/toml': 0.5.4
       eslint: 8.57.0
       eslint-formatting-reporter: 0.0.0(eslint@8.57.0)
-      eslint-parser-plain: 0.1.0
+      eslint-parser-plain: 0.1.0(patch_hash=2wwjuy7bj3rwnupmtdrepccgsy)
       prettier: 3.2.5
       synckit: 0.8.8
     dev: true


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/luxass/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Before this patch was applied, when eslint was set to cache it would fail to due to missing meta object.

The fix was to export the meta object.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
