### PR TITLE
feat: add eslint import plugin back

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Since flat config requires us to explicitly provide the plugin names (instead of
 
 | New Prefix                  | Original Prefix                     | Source Plugin                                                                                                                                    |
 | --------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `import/*`                  | `import-lite/*`                     | [eslint-plugin-import-lite](https://github.com/9romise/eslint-plugin-import-lite)                                                                |
 | `node/*`                    | `n/*`                               | [eslint-plugin-n](https://github.com/eslint-community/eslint-plugin-n)                                                                           |
 | `yaml/*`                    | `yml/*`                             | [eslint-plugin-yml](https://github.com/ota-meshi/eslint-plugin-yml)                                                                              |
 | `ts/*`                      | `@typescript-eslint/*`              | [@typescript-eslint/eslint-plugin](https://github.com/typescript-eslint/typescript-eslint)                                                       |

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "eslint-flat-config-utils": "catalog:prod",
     "eslint-merge-processors": "catalog:prod",
     "eslint-plugin-antfu": "catalog:prod",
+    "eslint-plugin-import-lite": "catalog:prod",
     "eslint-plugin-jsdoc": "catalog:prod",
     "eslint-plugin-jsonc": "catalog:prod",
     "eslint-plugin-n": "catalog:prod",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ catalogs:
     eslint-plugin-antfu:
       specifier: ^3.1.1
       version: 3.1.1
+    eslint-plugin-import-lite:
+      specifier: ^0.3.0
+      version: 0.3.0
     eslint-plugin-jsdoc:
       specifier: ^50.7.1
       version: 50.7.1
@@ -208,6 +211,9 @@ importers:
       eslint-plugin-antfu:
         specifier: catalog:prod
         version: 3.1.1(eslint@9.28.0(jiti@2.4.2))
+      eslint-plugin-import-lite:
+        specifier: catalog:prod
+        version: 0.3.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
       eslint-plugin-jsdoc:
         specifier: catalog:prod
         version: 50.7.1(eslint@9.28.0(jiti@2.4.2))
@@ -1627,6 +1633,16 @@ packages:
     resolution: {integrity: sha512-Tdns+CDjS+m7QrM85wwRi2yLae88XiWVdIOXjp9mDII0pmTBQlczPCmjpKnjiUIY3yPZNLqb5Ms/A/JXcBF2Dw==}
     peerDependencies:
       eslint: ^9.28.0
+
+  eslint-plugin-import-lite@0.3.0:
+    resolution: {integrity: sha512-dkNBAL6jcoCsXZsQ/Tt2yXmMDoNt5NaBh/U7yvccjiK8cai6Ay+MK77bMykmqQA2bTF6lngaLCDij6MTO3KkvA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^9.28.0
+      typescript: '>=4.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   eslint-plugin-jsdoc@50.7.1:
     resolution: {integrity: sha512-XBnVA5g2kUVokTNUiE1McEPse5n9/mNUmuJcx52psT6zBs2eVcXSmQBvjfa7NZdfLVSy3u1pEDDUxoxpwy89WA==}
@@ -4431,6 +4447,14 @@ snapshots:
       eslint-parser-plain: 0.1.1
       prettier: 3.4.2
       synckit: 0.9.3
+
+  eslint-plugin-import-lite@0.3.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.4.2))
+      '@typescript-eslint/types': 8.34.1
+      eslint: 9.28.0(jiti@2.4.2)
+    optionalDependencies:
+      typescript: 5.8.3
 
   eslint-plugin-jsdoc@50.7.1(eslint@9.28.0(jiti@2.4.2)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -47,6 +47,7 @@ catalogs:
     eslint-flat-config-utils: ^2.1.0
     eslint-merge-processors: ^2.0.0
     eslint-plugin-antfu: ^3.1.1
+    eslint-plugin-import-lite: ^0.3.0
     eslint-plugin-jsdoc: ^50.7.1
     eslint-plugin-jsonc: ^2.20.1
     eslint-plugin-n: ^17.19.0

--- a/src/configs/imports.ts
+++ b/src/configs/imports.ts
@@ -1,6 +1,7 @@
 import type { TypedFlatConfigItem } from "../types";
 import type { StylisticConfig } from "./stylistic";
 import pluginAntfu from "eslint-plugin-antfu";
+import pluginImportLite from "eslint-plugin-import-lite";
 
 export interface ImportsOptions {
   /**
@@ -9,20 +10,43 @@ export interface ImportsOptions {
    * @default true
    */
   stylistic?: boolean | StylisticConfig;
+
+  /**
+   * Overrides for the config.
+   */
+  overrides?: TypedFlatConfigItem["rules"];
 }
 
-export async function imports(_options: ImportsOptions = {}): Promise<TypedFlatConfigItem[]> {
+export async function imports(options: ImportsOptions = {}): Promise<TypedFlatConfigItem[]> {
+  const {
+    overrides = {},
+    stylistic = true,
+  } = options;
   return [
     {
       name: "luxass/imports",
       plugins: {
         antfu: pluginAntfu,
+        import: pluginImportLite,
       },
       rules: {
         "antfu/import-dedupe": "error",
         "antfu/no-import-dist": "error",
         "antfu/no-import-node-modules-by-path": "error",
 
+        "import/consistent-type-specifier-style": ["error", "top-level"],
+        "import/first": "error",
+        "import/no-duplicates": "error",
+        "import/no-mutable-exports": "error",
+        "import/no-named-default": "error",
+
+        ...stylistic
+          ? {
+              "import/newline-after-import": ["error", { count: 1 }],
+            }
+          : {},
+
+        ...overrides,
       },
     },
   ];

--- a/src/configs/stylistic.ts
+++ b/src/configs/stylistic.ts
@@ -66,11 +66,6 @@ export async function stylistic(options: StylisticOptions = {}): Promise<TypedFl
         "style/brace-style": ["error", "1tbs", { allowSingleLine: true }],
 
         "style/generator-star-spacing": ["error", { after: true, before: false }],
-        "style/padding-line-between-statements": [
-          "error",
-          { blankLine: "always", next: "*", prev: "import" },
-          { blankLine: "any", next: "import", prev: "import" },
-        ],
         "style/yield-star-spacing": ["error", { after: true, before: false }],
 
         ...overrides,

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -62,6 +62,7 @@ export const defaultPluginRenaming = {
   "@eslint-react/naming-convention": "react-naming-convention",
   "@stylistic": "style",
   "@typescript-eslint": "ts",
+  "import-lite": "import",
   "n": "node",
   "vitest": "test",
   "yml": "yaml",
@@ -86,6 +87,7 @@ export function luxass(
     autoRenamePlugins = true,
     exts = [],
     gitignore: enableGitignore = true,
+    imports: enableImports = true,
     jsx: enableJsx = true,
     pnpm: enableCatalogs = false,
     react: enableReact = false,
@@ -155,6 +157,19 @@ export function luxass(
 
     perfectionist(),
   );
+
+  if (enableImports) {
+    configs.push(
+      imports(enableImports === true
+        ? {
+            stylistic: stylisticOptions,
+          }
+        : {
+            stylistic: stylisticOptions,
+            ...enableImports,
+          }),
+    );
+  }
 
   if (enableUnicorn) {
     configs.push(unicorn(enableUnicorn === true ? {} : enableUnicorn));

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import type { FlatGitignoreOptions } from "eslint-config-flat-gitignore";
 import type {
   AstroOptions,
   FormattersOptions,
+  ImportsOptions,
   JavaScriptOptions,
   JSONOptions,
   ReactOptions,
@@ -64,6 +65,13 @@ export interface ConfigOptions {
    * @default true
    */
   unicorn?: boolean | UnicornOptions;
+
+  /**
+   * Options for eslint-plugin-import-lite.
+   *
+   * @default true
+   */
+  imports?: boolean | ImportsOptions;
 
   /**
    * Control to disable some rules in editors.


### PR DESCRIPTION
This adds the Import plugin back, but uses a much more lightweight version of it.