### PR TITLE
ci: try out oidc publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ jobs:
       - name: publish to npm
         run: pnpm publish --access public --no-git-checks
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
       - name: print dirty files


### PR DESCRIPTION
https://docs.npmjs.com/trusted-publishers
https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow by removing the use of an environment variable related to publishing to npm.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->